### PR TITLE
Turn contact info into clickable links

### DIFF
--- a/src/components/DetailedRequest.vue
+++ b/src/components/DetailedRequest.vue
@@ -22,11 +22,15 @@
           <h1 class="font-bold text-lg">Kontaktinformasjon</h1>
           <div class="flex">
             <p class="font-bold">Epost:</p>
-            <div class="ml-2">{{ request.email }}</div>
+            <div class="ml-2">
+              <a class="link" :href="getEmailLink">{{ request.email }}</a>
+            </div>
           </div>
           <div class="flex">
             <p class="font-bold">Telefon:</p>
-            <div class="ml-2">{{ request.phoneNumber }}</div>
+            <div class="ml-2">
+              <a class="link" :href="getPhoneLink">{{ request.phoneNumber }}</a>
+            </div>
           </div>
           <div class="flex">
             <p class="font-bold">Betalingsmåte:</p>
@@ -56,6 +60,27 @@ export default {
     }
   },
   methods: {},
-  computed: {}
+  computed: {
+    getPhoneLink() {
+      return `tel:+47${this.request.phoneNumber}`;
+    },
+    getEmailLink() {
+      return `mailto:${this.request.email}`;
+    }
+  }
 };
 </script>
+
+<style scoped>
+.link {
+  color: #038df0;
+}
+
+.link:hover {
+  text-decoration: underline;
+}
+
+.link:active {
+  color: #004bac;
+}
+</style>

--- a/src/components/DetailedRequest.vue
+++ b/src/components/DetailedRequest.vue
@@ -62,7 +62,7 @@ export default {
   methods: {},
   computed: {
     getPhoneLink() {
-      return `tel:+47${this.request.phoneNumber}`;
+      return `tel:${this.request.phoneNumber}`;
     },
     getEmailLink() {
       return `mailto:${this.request.email}`;

--- a/src/components/LoginButton.vue
+++ b/src/components/LoginButton.vue
@@ -57,7 +57,7 @@ export default {
   #btnText {
     display: flex;
     align-items: center;
-    padding: 0 0.3rem;
+    padding: 0 0.5rem;
   }
 }
 </style>

--- a/src/components/Request.vue
+++ b/src/components/Request.vue
@@ -6,9 +6,7 @@
     <p class="text-xl underline p-2">
       Handleliste:
     </p>
-    <div class="p-2 truncate">
-      {{ getItemNames }}
-    </div>
+    <div class="p-2 truncate" v-html="getItems" />
     <Button
       btnText="Se forespørsel"
       @btnClicked="seeMore"
@@ -38,8 +36,10 @@ export default {
     }
   },
   computed: {
-    getItemNames() {
-      return this.request.items.map(item => item.itemName).join(", ");
+    getItems() {
+      return this.request.items
+        .map(item => `<b>${item.count}x</b> ${item.itemName}`)
+        .join(", ");
     },
     userIsAssigned() {
       return (


### PR DESCRIPTION
Turns the phone number and mail address into clickable links.

Jif:
![clickable](https://user-images.githubusercontent.com/41551253/76887836-280a7580-6883-11ea-96f3-23d7239f2dbf.gif)

satisfies #77 