### PR TITLE
Make CD use envoriment variables when building during deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,3 +1,4 @@
+
 name: Continuous Deployment
 
 on:
@@ -18,7 +19,8 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-        
+    - name: Create env file
+      run: echo -e "VUE_APP_MAPBOX_TOKEN=${{secrets.MAPBOX_TOKEN}}\nVUE_APP_FIREBASE_CONFIG=${{secrets.FIREBASE_CONFIG}}\nVUE_APP_ACCOUNT_SID=${{secrets.ACCOUNT_SID}}\nVUE_APP_AUTH_TOKEN=${{secrets.AUTH_TOKEN}}" > .env
     - run: npm install
     - run: npm run build
     - name: Deploy to firebase

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,10 +1,8 @@
-
 name: Continuous Deployment
 
 on:
   release:
     types: [published]
-
 
 jobs:
   deploy:
@@ -14,18 +12,21 @@ jobs:
         node-version: [10.x]
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-    - name: Create env file
-      run: echo -e "VUE_APP_MAPBOX_TOKEN=${{secrets.MAPBOX_TOKEN}}\nVUE_APP_FIREBASE_CONFIG=${{secrets.FIREBASE_CONFIG}}\nVUE_APP_ACCOUNT_SID=${{secrets.ACCOUNT_SID}}\nVUE_APP_AUTH_TOKEN=${{secrets.AUTH_TOKEN}}" > .env
-    - run: npm install
-    - run: npm run build
-    - name: Deploy to firebase
-      uses: w9jds/firebase-action@master
-      with:
-        args: deploy --only hosting
-      env:
-        FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm install
+      - run: npm run build
+        env:
+          VUE_APP_MAPBOX_TOKEN: ${{ secrets.MAPBOX_TOKEN }}
+          VUE_APP_FIREBASE_CONFIG: ${{ secrets.FIREBASE_CONFIG }}
+          VUE_APP_ACCOUNT_SID: ${{ secrets.ACCOUNT_SID }}
+          VUE_APP_AUTH_TOKEN: ${{ secrets.AUTH_TOKEN }}
+      - name: Deploy to firebase
+        uses: w9jds/firebase-action@master
+        with:
+          args: deploy --only hosting
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}


### PR DESCRIPTION
You have to set a number of github secrets for this to work tho. With this it should create a deployment everytime we create a release here