### PR TITLE
Remove ugly arrows on input field

### DIFF
--- a/src/common/base.scss
+++ b/src/common/base.scss
@@ -47,7 +47,7 @@ label {
 }
 
 input[type="text"],
-input[type="number"],
+input[type="tel"],
 textarea {
   width: 100%;
   color: $color-text;
@@ -58,7 +58,7 @@ textarea {
 }
 
 input[type="text"],
-input[type="number"] {
+input[type="tel"] {
   max-width: 200px;
 }
 

--- a/src/components/shared/NumberInput.vue
+++ b/src/components/shared/NumberInput.vue
@@ -2,7 +2,7 @@
   <div>
     <label for="number-input">{{ labelText }}</label>
     <input
-      type="number"
+      type="tel"
       name="number-input"
       @input="emitNumberInput"
       :placeholder="placeholderText"


### PR DESCRIPTION
On firefox you have these ugly arrows which are pointless since it's a phone number. Not something you would ever want to increment. 
https://i.imgur.com/FHuMgjH.png
