### PR TITLE
Oppdater issue-template til å ikke vise hjelpeteksten

### DIFF
--- a/.github/ISSUE_TEMPLATE/rapporter-en-feil.md
+++ b/.github/ISSUE_TEMPLATE/rapporter-en-feil.md
@@ -7,8 +7,8 @@ assignees: ''
 
 ---
 
-**Beskriv hva som skjer **
-Kort og konsist hva som skjedde
+**Beskriv hva som skjer**
+<!--Kort og konsist hva som skjedde-->
 
 **Annet**
-Gjerne skriv hvilken device du er på og hva slags browser du bruker, og annet du tenker er nyttig,
+<!--Gjerne skriv hvilken device du er på og hva slags browser du bruker, og annet du tenker er nyttig.-->


### PR DESCRIPTION
Setter hjelpetekst som kommentarer, og fikser slik at "Beskriv hva som skjedde" faktisk blir boldet, som så ut som var intensjonen.