### PR TITLE
Load header without login

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,6 @@
 <template>
   <div id="app">
-    <Menu />
+    <Menu v-if="shouldDisplayMenu" />
     <Page>
       <router-view />
     </Page>
@@ -18,6 +18,11 @@ export default {
     Menu,
     Page,
     Footer
+  },
+  computed: {
+    shouldDisplayMenu() {
+      return this.$route.path !== "/login";
+    }
   }
 };
 </script>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,6 @@
 <template>
   <div id="app">
-    <Menu v-if="getUser" />
+    <Menu />
     <Page>
       <router-view />
     </Page>
@@ -18,11 +18,6 @@ export default {
     Menu,
     Page,
     Footer
-  },
-  computed: {
-    getUser() {
-      return this.$store.getters.currentUser;
-    }
   }
 };
 </script>

--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -135,6 +135,7 @@ export default {
         .then(() => {
           this.$store.dispatch("SET_CURRENT_USER", null);
           this.$router.push("/login");
+          this.close();
         })
         .catch(error => {
           console.log(`something went wrong ${error.message}`);


### PR DESCRIPTION
Gjør så headeren vises uansett om du er logget inn eller ikke.

**Merk:** _Dette legger også til headeren på loginsiden, som kanskje er uønskelig? Den ser i det minste ganske clean ut uten._

Tenker det skal være noen routes som skal være tilgjengelige uten login, som FAQ eller About. Skal isåfall være ganske lett å vise menyen også uten login, og bare vise linker for sider som er åpne.

Går fra dette:
![Peek 2020-03-19 12-18](https://user-images.githubusercontent.com/14319313/77070280-3aeb8a00-69ea-11ea-86d4-c8f935ba53df.gif)

Til dette:
![Peek 2020-03-19 12-17](https://user-images.githubusercontent.com/14319313/77070296-42129800-69ea-11ea-85e8-50b545c13dce.gif)

