### PR TITLE
Add formatted 'createdOn' in request details

### DIFF
--- a/src/components/DetailedRequest.vue
+++ b/src/components/DetailedRequest.vue
@@ -5,9 +5,7 @@
       :locationCenter="request.address.center"
     />
     <hr />
-    <h3>
-      Kontaktinformasjon
-    </h3>
+    <h3>Kontaktinformasjon</h3>
     <p>
       <icon name="email" />
       <a :href="getEmailLink">{{ request.email }}</a>
@@ -15,10 +13,21 @@
     <p>
       <icon name="phone" />
       <a :href="getPhoneLink">{{ request.phoneNumber }}</a>
-      Du kan endre ditt telefonnummer på <a href="/my-page">Min side</a>
+      Du kan endre ditt telefonnummer på
+      <a href="/my-page">Min side</a>
     </p>
-    <p><icon name="credit_card" /> {{ request.paymentSolution }}</p>
-    <p><icon name="directions_walk" />{{ request.arrivalDescription }}</p>
+    <p>
+      <icon name="credit_card" />
+      {{ request.paymentSolution }}
+    </p>
+    <p v-if="request.createdOn">
+      <icon name="schedule" />
+      {{ getFormattedCreatedOn }}
+    </p>
+    <p>
+      <icon name="directions_walk" />
+      {{ request.arrivalDescription }}
+    </p>
 
     <h3 v-if="request.items.length">Handleliste</h3>
     <ul v-if="request.items.length">
@@ -28,18 +37,16 @@
       </li>
     </ul>
 
-    <h3 v-if="request.otherNeed">
-      Annen henvendelse
-    </h3>
-    <p v-if="request.otherNeed">
-      {{ request.otherNeed }}
-    </p>
+    <h3 v-if="request.otherNeed">Annen henvendelse</h3>
+    <p v-if="request.otherNeed">{{ request.otherNeed }}</p>
   </section>
 </template>
 
 <script>
 import Map from "@/components/Map.vue";
 import Icon from "@/components/shared/Icon.vue";
+
+import formatDateTime from "@/helpers/datetime";
 
 export default {
   name: "DetailedRequest",
@@ -74,6 +81,10 @@ export default {
     },
     getEmailLink() {
       return `mailto:${this.request.email}`;
+    },
+    getFormattedCreatedOn() {
+      const { createdOn } = this.request;
+      return createdOn && formatDateTime(createdOn.toDate());
     }
   }
 };

--- a/src/components/Request.vue
+++ b/src/components/Request.vue
@@ -3,7 +3,14 @@
     <h3>
       {{ request.address.place_name_no }}
     </h3>
-    <p v-if="showDistance">{{ distance | asUnit }} unna deg</p>
+    <p v-if="showDistance">
+      <icon name="place" />
+      {{ distance | asUnit }} unna deg
+    </p>
+    <p>
+      <icon name="schedule" />
+      {{ getFormattedCreatedOn }}
+    </p>
     <strong v-if="request.items.length">
       Handleliste:
     </strong>
@@ -31,9 +38,11 @@
 
 <script>
 import Button from "@/components/shared/Button.vue";
+import Icon from "@/components/shared/Icon.vue";
 import Info from "@/components/shared/Info.vue";
 
 import coordinateDistance from "@/helpers/coord";
+import formatDateTime from "@/helpers/datetime";
 
 export default {
   name: "Request",
@@ -45,6 +54,7 @@ export default {
   },
   components: {
     Button,
+    Icon,
     Info
   },
   methods: {
@@ -88,6 +98,10 @@ export default {
         this.request.connectedUser &&
         this.request.connectedUser.email === this.$store.getters.email
       );
+    },
+    getFormattedCreatedOn() {
+      const { createdOn } = this.request;
+      return createdOn && formatDateTime(createdOn.toDate());
     }
   }
 };

--- a/src/helpers/datetime.js
+++ b/src/helpers/datetime.js
@@ -1,0 +1,14 @@
+const LOCALE = "nb-NO";
+
+export default function formatDateTime(date) {
+  const options = {
+    weekday: "long",
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    hour: "numeric",
+    minute: "numeric"
+  };
+  const formatter = new Intl.DateTimeFormat(LOCALE, options);
+  return formatter.format(date);
+}


### PR DESCRIPTION
La til felt som viser når et oppdrag ble opprettet.
Feltet vises kun i detaljvisningen, og bare etter oppdraget faktisk har blitt opprettet.

![Screenshot from 2020-03-19 15-13-49](https://user-images.githubusercontent.com/14319313/77076720-7c813280-69f4-11ea-848b-784d03dfc407.png)

Resolves #116 