### PR TITLE
Reduce bundle size

### DIFF
--- a/src/components/DetailedRequest.vue
+++ b/src/components/DetailedRequest.vue
@@ -49,10 +49,11 @@
 </template>
 
 <script>
-import Map from "@/components/Map.vue";
 import Icon from "@/components/shared/Icon.vue";
 
 import formatDateTime from "@/helpers/datetime";
+
+const Map = () => import("@/components/Map.vue");
 
 export default {
   name: "DetailedRequest",

--- a/src/components/GoogleLoginButton.vue
+++ b/src/components/GoogleLoginButton.vue
@@ -8,7 +8,7 @@
 </template>
 
 <script>
-import firebase from "firebase";
+import firebase from "firebase/app";
 
 export default {
   name: "LoginButton",

--- a/src/components/LoginArea.vue
+++ b/src/components/LoginArea.vue
@@ -25,7 +25,8 @@
 </template>
 
 <script>
-import firebase from "firebase";
+import firebase from "firebase/app";
+
 import {
   handleSignedIn,
   getErrorMessage,
@@ -76,28 +77,30 @@ export default {
   async beforeMount() {
     const login = async url => {
       try {
-        const fb = firebase.auth();
-        if (fb.isSignInWithEmailLink(url)) {
+        if (firebase.auth().isSignInWithEmailLink(url)) {
           let email = window.localStorage.getItem("emailForSignIn");
           if (!email) {
             // If the user opens the link on another device
-            email = await this.$dialog.prompt(
-              {
-                title: "Epostadresse",
-                body: "Skriv inn epostadressen din",
-                promptHelp: `Skriv din epostadresse i boksen under og trykk "[+:okText]"`
-              },
-              {
-                okText: "Fortsett",
-                cancelText: "Lukk",
-                customClass: "phone-prompt"
-              }
-            ).then(dialog => dialog.data);
+            email = await this.$dialog
+              .prompt(
+                {
+                  title: "Epostadresse",
+                  body: "Skriv inn epostadressen din",
+                  promptHelp: `Skriv din epostadresse i boksen under og trykk "[+:okText]"`
+                },
+                {
+                  okText: "Fortsett",
+                  cancelText: "Lukk",
+                  customClass: "phone-prompt"
+                }
+              )
+              .then(dialog => dialog.data);
           }
-          await fb
+          await firebase
+            .auth()
             .signInWithEmailLink(email, url)
-            .then(() => handleSignedIn(this, fb.currentUser))
-            .then(() => window.localStorage.removeItem("emailForSignIn"))
+            .then(() => handleSignedIn(this, firebase.auth().auth.currentUser))
+            .then(() => window.localStorage.removeItem("emailForSignIn"));
         }
       } catch (err) {
         this.errorCode = err.code;

--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -77,7 +77,7 @@
 </template>
 
 <script>
-import fb from "firebase";
+import firebase from "firebase/app";
 
 export default {
   name: "Menu",
@@ -130,7 +130,8 @@ export default {
       this.close();
     },
     logout() {
-      fb.auth()
+      firebase
+        .auth()
         .signOut()
         .then(() => {
           this.$store.dispatch("SET_CURRENT_USER", null);

--- a/src/firebaseConfig.js
+++ b/src/firebaseConfig.js
@@ -1,6 +1,7 @@
 import firebase from "firebase/app";
 
 import "firebase/auth";
+import "firebase/firestore";
 
 firebase.initializeApp(JSON.parse(process.env.VUE_APP_FIREBASE_CONFIG));
 

--- a/src/helpers/auth.js
+++ b/src/helpers/auth.js
@@ -1,7 +1,7 @@
-import firebase from "firebase";
+import firebase from "firebase/app";
 import fb from "@/firebaseConfig.js";
 
-export const handleSignedIn = async(context, user) => {
+export const handleSignedIn = async (context, user) => {
   if (!user.displayName) {
     await context.$dialog
       .prompt(

--- a/src/helpers/datetime.js
+++ b/src/helpers/datetime.js
@@ -1,5 +1,5 @@
-import { formatDistanceToNow } from "date-fns";
-import { nb } from "date-fns/locale";
+import formatDistanceToNow from "date-fns/formatDistanceToNow";
+import nb from "date-fns/locale/nb";
 
 export default function formatDateTime(date) {
   return `${formatDistanceToNow(date, { locale: nb }).replace(

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,15 +1,26 @@
 import Vue from "vue";
 import VueRouter from "vue-router";
-import Login from "@/views/Login.vue";
-import AllRequests from "@/views/AllRequests.vue";
-import CreateRequestView from "@/views/CreateRequestView.vue";
-import StartScreenView from "@/views/StartScreenView.vue";
-import RequestView from "@/views/RequestView.vue"; // eslint-disable
-import MyRequestsView from "@/views/MyRequestsView.vue"; // eslint-disable
-import MyAssignedRequestsView from "@/views/MyAssignedRequestsView.vue"; // eslint-disable
-import EditRequestView from "@/views/EditRequestView.vue";
-import MyPageView from "@/views/MyPageView.vue";
-import firebase from "firebase";
+import firebase from "firebase/app";
+
+const Login = () => import(/* webpackChunkName: "main" */ "@/views/Login.vue");
+const AllRequests = () =>
+  import(/* webpackChunkName: "requests" */ "@/views/AllRequests.vue");
+const CreateRequestView = () =>
+  import(/* webpackChunkName: "requests" */ "@/views/CreateRequestView.vue");
+const StartScreenView = () =>
+  import(/* webpackChunkName: "requests" */ "@/views/StartScreenView.vue");
+const RequestView = () =>
+  import(/* webpackChunkName: "requests" */ "@/views/RequestView.vue");
+const MyRequestsView = () =>
+  import(/* webpackChunkName: "requests" */ "@/views/MyRequestsView.vue");
+const MyAssignedRequestsView = () =>
+  import(
+    /* webpackChunkName: "requests" */ "@/views/MyAssignedRequestsView.vue"
+  );
+const EditRequestView = () =>
+  import(/* webpackChunkName: "requests" */ "@/views/EditRequestView.vue");
+const MyPageView = () =>
+  import(/* webpackChunkName: "profile" */ "@/views/MyPageView.vue");
 
 Vue.use(VueRouter);
 

--- a/src/views/AllRequests.vue
+++ b/src/views/AllRequests.vue
@@ -35,9 +35,10 @@
 
 <script>
 import Request from "@/components/Request.vue";
-import AllRequestsMap from "@/components/AllRequestsMap.vue";
 import coordinateDistance from "@/helpers/coord";
 import Icon from "@/components/shared/Icon.vue";
+
+const AllRequestsMap = () => import("@/components/AllRequestsMap.vue");
 
 export default {
   name: "MyRequests",

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -32,7 +32,7 @@
 <script>
 import GoogleLoginButton from "@/components/GoogleLoginButton.vue";
 import LoginArea from "@/components/LoginArea.vue";
-import firebase from "firebase";
+import firebase from "firebase/app";
 import { handleSignedIn } from "@/helpers/auth";
 
 export default {

--- a/src/views/MyPageView.vue
+++ b/src/views/MyPageView.vue
@@ -34,8 +34,8 @@
 <script>
 import Button from "@/components/shared/Button.vue";
 import PhoneNumberInput from "@/components/shared/PhoneNumberInput.vue";
+import firebase from "firebase/app";
 import fb from "@/firebaseConfig.js";
-import firebase from "firebase";
 
 export default {
   name: "MyPage",


### PR DESCRIPTION
Har jobbet litt med å minke tiden for initial load, first paint og slikt.

Initiativer for å minke bundle-size:
- Importere kun relevante deler av biblioteker, som firebase og date-fns
- Importere større biblioteker som egne bundles fordi de brukes sjeldent, som Mapbox
- Dele opp applikasjonen i flere bundles basert på forskjellige views. Du trenger altså bare laste inn koden for viewet du er i nå, og kanskje andre relevante views.

Har delt opp views i 3 forskjellige typer:
- `main`, som er login og eventuelt annet en ønsker skal være veldig lett tilgjengelig
- `requests`, som er alle sidene som har med requests å gjøre. Hadde vært nice å bare trenge å laste inn `firebase/firestore` hvis du skal til disse rutene?
- `profile`, som er views relatert til brukerprofilen

Mapbox-relaterte komponenter lastes også inn med dynamiske imports. Dette betyr at hele mapbox venter med å laste inn til det trengs.

_Trenger litt mer innsyn_